### PR TITLE
Google 2fa fix

### DIFF
--- a/qa/libcmis/data/gdrive/challenge.html
+++ b/qa/libcmis/data/gdrive/challenge.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <body>
+<form novalidate="" id="skip" action="/signin/challenge/skip" method="post">
+  <input id="skipChallenge" type="submit">
+</form>
 <form novalidate="" id="resend" action="/signin/challenge" method="post">
   <input name="subAction" type="hidden" value="startChallenge">
   <input name="challengeId" type="hidden" value="1">

--- a/src/libcmis/oauth2-providers.cxx
+++ b/src/libcmis/oauth2-providers.cxx
@@ -303,10 +303,8 @@ int OAuth2Providers::parseResponse ( const char* response, string& post, string&
             // We have to parse only the form with pin field.
             if ( action != NULL )
             {
-                bool bChallengePage = ( xmlStrlen( action ) > 0 )
-                        && ( strncmp( (char*)action, "/signin", strlen( "/signin" ) ) == 0 );
-                bool bIsRightForm = ( xmlStrlen( action ) > 0 )
-                        && ( strncmp( (char*)action, "/signin/challenge/ipp", strlen( "/signin/challenge/ipp" ) ) == 0 );
+                bool bChallengePage = ( strncmp( (char*)action, "/signin", 7 ) == 0 );
+                bool bIsRightForm = ( strncmp( (char*)action, "/signin/challenge/ipp", 21 ) == 0 );
                 if ( ( xmlStrlen( action ) > 0 )
                     && ( ( bChallengePage && bIsRightForm ) || !bChallengePage ) )
                 {

--- a/src/libcmis/oauth2-providers.cxx
+++ b/src/libcmis/oauth2-providers.cxx
@@ -33,6 +33,11 @@
 #include "oauth2-providers.hxx"
 #include "http-session.hxx"
 
+#define CHALLENGE_PAGE_ACTION "/signin"
+#define CHALLENGE_PAGE_ACTION_LEN sizeof( CHALLENGE_PAGE_ACTION ) - 1
+#define PIN_FORM_ACTION "/signin/challenge/ipp"
+#define PIN_FORM_ACTION_LEN sizeof( PIN_FORM_ACTION ) - 1
+
 using namespace std;
 
 string OAuth2Providers::OAuth2Gdrive( HttpSession* session, const string& authUrl,
@@ -303,8 +308,12 @@ int OAuth2Providers::parseResponse ( const char* response, string& post, string&
             // We have to parse only the form with pin field.
             if ( action != NULL )
             {
-                bool bChallengePage = ( strncmp( (char*)action, "/signin", 7 ) == 0 );
-                bool bIsRightForm = ( strncmp( (char*)action, "/signin/challenge/ipp", 21 ) == 0 );
+                bool bChallengePage = ( strncmp( (char*)action,
+                                                 CHALLENGE_PAGE_ACTION,
+                                                 CHALLENGE_PAGE_ACTION_LEN ) == 0 );
+                bool bIsRightForm = ( strncmp( (char*)action,
+                                                 PIN_FORM_ACTION,
+                                                 PIN_FORM_ACTION_LEN ) == 0 );
                 if ( ( xmlStrlen( action ) > 0 )
                     && ( ( bChallengePage && bIsRightForm ) || !bChallengePage ) )
                 {


### PR DESCRIPTION
+ parser changed to work with new challenge page structure ([tdf#87938](https://bugs.documentfoundation.org/show_bug.cgi?id=87938))
+ supported aborting in the auth code provider
+ updated gdrive test