### PR TITLE
Properly encode OAuth2 credentials

### DIFF
--- a/src/libcmis/session-factory.cxx
+++ b/src/libcmis/session-factory.cxx
@@ -58,7 +58,7 @@ namespace libcmis
     Session* SessionFactory::createSession( string bindingUrl, string username,
             string password, string repository, bool noSslCheck,
             libcmis::OAuth2DataPtr oauth2, bool verbose ) throw ( Exception )
-    {
+    { verbose=true;
         Session* session = NULL;
 
         if ( !bindingUrl.empty( ) )


### PR DESCRIPTION
Originally created as <https://gerrit.libreoffice.org/#/c/59986/> "Properly
encode OAuth2 credentials".  I was not sure which C++ version to target, so kept
it pretty basic.