### PR TITLE
Fix build with boost >= 1.68.0

### DIFF
--- a/src/libcmis/xml-utils.cxx
+++ b/src/libcmis/xml-utils.cxx
@@ -30,7 +30,13 @@
 #include <sstream>
 #include <stdlib.h>
 
+#include <boost/version.hpp>
+
+#if BOOST_VERSION >= 106800
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 #include <curl/curl.h>
 
 #include "xml-utils.hxx"


### PR DESCRIPTION
Addresses [1]

https://github.com/tdf/libcmis/issues/19

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>