### PR TITLE
Added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ addons:
 compiler:
   - gcc
   - clang
+arch:
+  - amd64
+  - ppc64le
 
 script:
   - ./autogen.sh && make && make check

--- a/inc/libcmis-c/repository.h
+++ b/inc/libcmis-c/repository.h
@@ -29,7 +29,7 @@
 #define _REPOSITORY_H_
 
 #ifdef __cplusplus
-extern "C" {
+extern "C++" {
 #endif
 
 #include <libxml/tree.h>


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/libcmis/builds/181286010 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!