### PR TITLE
Fix build with libxml2-2.12 (missing include)

### DIFF
--- a/inc/libcmis/xml-utils.hxx
+++ b/inc/libcmis/xml-utils.hxx
@@ -34,6 +34,7 @@
 #include <string>
 
 #include <boost/date_time.hpp>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpathInternals.h>
 #include <libxml/xmlwriter.h>


### PR DESCRIPTION
See also: https://github.com/tdf/libcmis/issues/51