### PR TITLE
Fix warning C4589 when building with MSVC

### DIFF
--- a/inc/libcmis/document.hxx
+++ b/inc/libcmis/document.hxx
@@ -48,7 +48,6 @@ namespace libcmis
     class LIBCMIS_API Document : public virtual Object
     {
         public:
-            Document( Session* session ) : Object( session ) { }
             virtual ~Document( ) { }
 
             /** Get the folder parents for the document.

--- a/inc/libcmis/folder.hxx
+++ b/inc/libcmis/folder.hxx
@@ -55,7 +55,6 @@ namespace libcmis
     class LIBCMIS_API Folder : public virtual Object
     {
         public:
-            Folder( Session* session ) : Object( session ) { }
             virtual ~Folder() { }
 
             virtual std::vector< std::string > getPaths( );

--- a/src/libcmis/atom-document.cxx
+++ b/src/libcmis/atom-document.cxx
@@ -43,7 +43,6 @@ using namespace libcmis;
 
 AtomDocument::AtomDocument( AtomPubSession* session ) :
     libcmis::Object( session ),
-    libcmis::Document( session ),
     AtomObject( session ),
     m_contentUrl( )
 {
@@ -52,7 +51,6 @@ AtomDocument::AtomDocument( AtomPubSession* session ) :
 
 AtomDocument::AtomDocument( AtomPubSession* session, xmlNodePtr entryNd ) :
     libcmis::Object( session ),
-    libcmis::Document( session ),
     AtomObject( session ),
     m_contentUrl( )
 {

--- a/src/libcmis/atom-folder.cxx
+++ b/src/libcmis/atom-folder.cxx
@@ -46,7 +46,6 @@ namespace
 
 AtomFolder::AtomFolder( AtomPubSession* session, xmlNodePtr entryNd ) :
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     AtomObject( session )
 {
     xmlDocPtr doc = libcmis::wrapInDoc( entryNd );

--- a/src/libcmis/gdrive-document.cxx
+++ b/src/libcmis/gdrive-document.cxx
@@ -40,7 +40,6 @@ using namespace libcmis;
 
 GDriveDocument::GDriveDocument( GDriveSession* session ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     GDriveObject( session ),
     m_isGoogleDoc( false )
 {
@@ -48,7 +47,6 @@ GDriveDocument::GDriveDocument( GDriveSession* session ) :
 
 GDriveDocument::GDriveDocument( GDriveSession* session, Json json, string id, string name ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     GDriveObject( session, json, id, name ),
     m_isGoogleDoc( false )
 {

--- a/src/libcmis/gdrive-folder.cxx
+++ b/src/libcmis/gdrive-folder.cxx
@@ -38,14 +38,12 @@ using namespace libcmis;
 
 GDriveFolder::GDriveFolder( GDriveSession* session ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     GDriveObject( session )
 {
 }
 
 GDriveFolder::GDriveFolder( GDriveSession* session, Json json ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     GDriveObject( session, json )
 {
 }

--- a/src/libcmis/onedrive-document.cxx
+++ b/src/libcmis/onedrive-document.cxx
@@ -40,14 +40,12 @@ using namespace libcmis;
 
 OneDriveDocument::OneDriveDocument( OneDriveSession* session ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     OneDriveObject( session )
 {
 }
 
 OneDriveDocument::OneDriveDocument( OneDriveSession* session, Json json, string id, string name ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     OneDriveObject( session, json, id, name )
 {
 }

--- a/src/libcmis/onedrive-folder.cxx
+++ b/src/libcmis/onedrive-folder.cxx
@@ -38,14 +38,12 @@ using namespace libcmis;
 
 OneDriveFolder::OneDriveFolder( OneDriveSession* session ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     OneDriveObject( session )
 {
 }
 
 OneDriveFolder::OneDriveFolder( OneDriveSession* session, Json json ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     OneDriveObject( session, json )
 {
 }

--- a/src/libcmis/sharepoint-document.cxx
+++ b/src/libcmis/sharepoint-document.cxx
@@ -37,14 +37,12 @@ using namespace libcmis;
 
 SharePointDocument::SharePointDocument( SharePointSession* session ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     SharePointObject( session )
 {
 }
 
 SharePointDocument::SharePointDocument( SharePointSession* session, Json json, string parentId, string name ) :
     libcmis::Object( session),
-    libcmis::Document( session ),
     SharePointObject( session, json, parentId, name )
 {
 }

--- a/src/libcmis/sharepoint-folder.cxx
+++ b/src/libcmis/sharepoint-folder.cxx
@@ -38,14 +38,12 @@ using namespace libcmis;
 
 SharePointFolder::SharePointFolder( SharePointSession* session ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     SharePointObject( session )
 {
 }
 
 SharePointFolder::SharePointFolder( SharePointSession* session, Json json, string parentId ):
     libcmis::Object( session ),
-    libcmis::Folder( session ),
     SharePointObject( session, json, parentId )
 {
 }

--- a/src/libcmis/ws-document.cxx
+++ b/src/libcmis/ws-document.cxx
@@ -33,7 +33,6 @@ using libcmis::PropertyPtrMap;
 
 WSDocument::WSDocument( const WSObject& object ) :
     libcmis::Object( object ),
-    libcmis::Document( const_cast< WSObject& >( object ).getSession( ) ),
     WSObject( object )
 {
 }

--- a/src/libcmis/ws-folder.cxx
+++ b/src/libcmis/ws-folder.cxx
@@ -33,7 +33,6 @@ using libcmis::PropertyPtrMap;
 
 WSFolder::WSFolder( const WSObject& object ) :
     libcmis::Object( object ),
-    libcmis::Folder( const_cast< WSObject& >( object ).getSession( ) ),
     WSObject( object )
 {
 }


### PR DESCRIPTION
C:\libcmis\inc\libcmis/document.hxx(51): warning C4589: Constructor of abstract class 'libcmis::Document' ignores initializer for virtual base class 'libcmis::Object'
C:\libcmis\inc\libcmis/document.hxx(51): note: virtual base classes are only initialized by the most-derived type
C:\libcmis\inc\libcmis/folder.hxx(58): warning C4589: Constructor of abstract class 'libcmis::Folder' ignores initializer for virtual base class 'libcmis::Object'
C:\libcmis\inc\libcmis/folder.hxx(58): note: virtual base classes are only initialized by the most-derived type