### PR TITLE
cppcheck: operatorEqVarError in src/libcmis/http-session.cxx

### DIFF
--- a/src/libcmis/http-session.cxx
+++ b/src/libcmis/http-session.cxx
@@ -224,6 +224,7 @@ HttpSession& HttpSession::operator=( const HttpSession& copy )
     {
         curl_easy_cleanup( m_curlHandle );
         m_curlHandle = NULL;
+        m_CurlInitProtocolsFunction = copy.m_CurlInitProtocolsFunction;
         m_no100Continue = copy.m_no100Continue;
         m_oauth2Handler = copy.m_oauth2Handler;
         m_username = copy.m_username;


### PR DESCRIPTION
cppcheck indicates:
src/libcmis/http-session.cxx:221:27: warning: Member variable 'HttpSession::m_CurlInitProtocolsFunction' is not assigned a value in 'HttpSession::operator='. [operatorEqVarError]
