### PR TITLE
cppcheck: fix "constParameterReference"

### DIFF
--- a/src/libcmis/ws-relatedmultipart.cxx
+++ b/src/libcmis/ws-relatedmultipart.cxx
@@ -240,7 +240,7 @@ string RelatedMultipart::addPart( RelatedPartPtr part )
     return cid;
 }
 
-void RelatedMultipart::setStart( string& cid, string& startInfo )
+void RelatedMultipart::setStart( string& cid, const string& startInfo )
 {
     RelatedPartPtr start = getPart( cid );
 

--- a/src/libcmis/ws-relatedmultipart.cxx
+++ b/src/libcmis/ws-relatedmultipart.cxx
@@ -223,7 +223,7 @@ vector< string > RelatedMultipart::getIds( )
     return ids;
 }
 
-RelatedPartPtr RelatedMultipart::getPart( string& cid )
+RelatedPartPtr RelatedMultipart::getPart( const string& cid )
 {
     RelatedPartPtr part;
     map< string, RelatedPartPtr >::iterator it = m_parts.find( cid );
@@ -240,7 +240,7 @@ string RelatedMultipart::addPart( RelatedPartPtr part )
     return cid;
 }
 
-void RelatedMultipart::setStart( string& cid, const string& startInfo )
+void RelatedMultipart::setStart( const string& cid, const string& startInfo )
 {
     RelatedPartPtr start = getPart( cid );
 

--- a/src/libcmis/ws-relatedmultipart.hxx
+++ b/src/libcmis/ws-relatedmultipart.hxx
@@ -108,7 +108,7 @@ class RelatedMultipart
             \param cid the Content-Id of the start entry
             \param startInfo the type to use as start-info in the Content-Type
           */
-        void setStart( std::string& cid, std::string& startInfo );
+        void setStart( std::string& cid, const std::string& startInfo );
 
         /** Compute the content type for the multipart object to set as the
             Content-Type HTTP header.

--- a/src/libcmis/ws-relatedmultipart.hxx
+++ b/src/libcmis/ws-relatedmultipart.hxx
@@ -88,7 +88,7 @@ class RelatedMultipart
 
         /** Get the entry corresponding to the given ID.
           */
-        RelatedPartPtr getPart( std::string& cid );
+        RelatedPartPtr getPart( const std::string& cid );
 
         /** Get the id of the multipart start entry.
           */
@@ -108,7 +108,7 @@ class RelatedMultipart
             \param cid the Content-Id of the start entry
             \param startInfo the type to use as start-info in the Content-Type
           */
-        void setStart( std::string& cid, const std::string& startInfo );
+        void setStart( const std::string& cid, const std::string& startInfo );
 
         /** Compute the content type for the multipart object to set as the
             Content-Type HTTP header.

--- a/src/libcmis/ws-soap.cxx
+++ b/src/libcmis/ws-soap.cxx
@@ -244,7 +244,7 @@ RelatedMultipart& SoapRequest::getMultipart( string& username, string& password 
     return m_multipart;
 }
 
-string SoapRequest::createEnvelope( string& username, string& password )
+string SoapRequest::createEnvelope( const string& username, const string& password )
 {
     xmlBufferPtr buf = xmlBufferCreate( );
     xmlTextWriterPtr writer = xmlNewTextWriterMemory( buf, 0 );

--- a/src/libcmis/ws-soap.hxx
+++ b/src/libcmis/ws-soap.hxx
@@ -172,7 +172,7 @@ class SoapRequest : public libcmis::XmlSerializable
 
     protected:
 
-        std::string createEnvelope( std::string& username, std::string& password );
+        std::string createEnvelope( const std::string& username, const std::string& password );
 };
 
 #endif


### PR DESCRIPTION
It allows to fix the 3 "constParameterReference" warnings found by cppcheck.