### PR TITLE
cppcheck: fix useStlAlgorithm

### DIFF
--- a/src/libcmis/gdrive-document.cxx
+++ b/src/libcmis/gdrive-document.cxx
@@ -69,35 +69,39 @@ string GDriveDocument::getDownloadUrl( string streamId )
     if ( !streamId.empty( ) )
     {
         // Find the rendition associated with the streamId
-        for ( vector< RenditionPtr >::iterator it = renditions.begin( ) ; 
-            it != renditions.end(); ++it )
+        for (const auto& renditionPtr : renditions)
         {
-            if ( (*it)->getStreamId( ) == streamId )
+            if (renditionPtr->getStreamId() == streamId)
             {
-                streamUrl = (*it)->getUrl( );
+                streamUrl = renditionPtr->getUrl();
                 break;
             }
-        }
+	}
     }
     else
     {
         // Automatically find the rendition
 
         // Prefer ODF format
-        for ( vector< RenditionPtr >::iterator it = renditions.begin( ) ; 
-            it != renditions.end(); ++it )
-            if ( (*it)->getMimeType( ).find( "opendocument") != string::npos )
-                return (*it)->getUrl( );
+        for (const auto& renditionPtr : renditions)
+        {
+            if (renditionPtr->getMimeType().find("opendocument") != std::string::npos)
+            {
+                return renditionPtr->getUrl();
+            }
+        }
 
         // Then MS format
-        for ( vector< RenditionPtr >::iterator it = renditions.begin( ) ; 
-            it != renditions.end(); ++it )
-            if ( (*it)->getMimeType( ).find( "officedocument") != string::npos )
-                return (*it)->getUrl( );
+        for (const auto& renditionPtr : renditions)
+        {
+            if (renditionPtr->getMimeType().find("officedocument") != std::string::npos)
+            {
+                return renditionPtr->getUrl();
+            }
+        }
 
         // If not found, take the first one
-        streamUrl = renditions.front( )->getUrl( );
-
+        streamUrl = renditions.front()->getUrl();
     }
 
     return streamUrl;

--- a/src/libcmis/json-utils.cxx
+++ b/src/libcmis/json-utils.cxx
@@ -159,11 +159,11 @@ void Json::add( const std::string& key, const Json& json )
 Json::JsonVector Json::getList()
 {
     JsonVector list;
-    for ( const auto &v: m_tJson.get_child("") )
+    for (const auto& v : m_tJson.get_child(""))
     {
-        list.push_back( Json( v.second  ) );
+        list.push_back(Json(v.second));
     }
-	return list ;
+    return list;
 }
 
 void Json::add( const Json& json )


### PR DESCRIPTION
src/libcmis/gdrive-document.cxx:76:13: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
src/libcmis/gdrive-document.cxx:89:0: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
src/libcmis/gdrive-document.cxx:95:0: style: Consider using std::find_if algorithm instead of a raw loop. [useStlAlgorithm]
src/libcmis/json-utils.cxx:164:14: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]