### PR TITLE
cppcheck: fix constVariablePointer

### DIFF
--- a/src/libcmis/atom-document.cxx
+++ b/src/libcmis/atom-document.cxx
@@ -300,7 +300,7 @@ void AtomDocument::cancelCheckout( )
 
     // Use working-copy link if provided as a workaround
     // for some non-compliant repositories
-    AtomLink* link = getLink( "working-copy", "application/atom+xml;type=entry" );
+    const AtomLink* link = getLink( "working-copy", "application/atom+xml;type=entry" );
     if ( link )
         url = link->getHref( );
 
@@ -394,7 +394,7 @@ vector< libcmis::DocumentPtr > AtomDocument::getAllVersions( )
         throw libcmis::Exception( string( "GetAllVersions not allowed on node " ) + getId() );
 
     vector< libcmis::DocumentPtr > versions;
-    AtomLink* link = getLink( "version-history", string( ) );
+    const AtomLink* link = getLink( "version-history", string( ) );
     if ( link != NULL )
     {
         string pageUrl = link->getHref( );

--- a/src/libcmis/atom-folder.cxx
+++ b/src/libcmis/atom-folder.cxx
@@ -60,7 +60,7 @@ AtomFolder::~AtomFolder( )
 
 vector< libcmis::ObjectPtr > AtomFolder::getChildren( )
 {
-    AtomLink* childrenLink = getLink( "down", "application/atom+xml;type=feed" );
+    const AtomLink* childrenLink = getLink( "down", "application/atom+xml;type=feed" );
 
     // Some servers aren't giving the GetChildren properly... if not defined, we need to try
     // as we may have the right to proceed.
@@ -263,7 +263,7 @@ libcmis::DocumentPtr AtomFolder::createDocument( const PropertyPtrMap& propertie
 vector< string > AtomFolder::removeTree( bool allVersions, libcmis::UnfileObjects::Type unfile,
         bool continueOnError )
 {
-    AtomLink* treeLink = getLink( "down", "application/cmistree+xml" );
+    const AtomLink* treeLink = getLink( "down", "application/cmistree+xml" );
     if ( NULL == treeLink )
         treeLink = getLink( "http://docs.oasis-open.org/ns/cmis/link/200908/foldertree", "application/cmistree+xml" );
 

--- a/src/libcmis/atom-object.cxx
+++ b/src/libcmis/atom-object.cxx
@@ -257,7 +257,7 @@ void AtomObject::move( boost::shared_ptr< libcmis::Folder > source, boost::share
     if ( NULL == atomDestination )
         throw libcmis::Exception( string( "Destination is not an AtomFolder" ) );
 
-    AtomLink* destChildrenLink = atomDestination->getLink( "down", "application/atom+xml;type=feed" );
+    const AtomLink* destChildrenLink = atomDestination->getLink( "down", "application/atom+xml;type=feed" );
 
     if ( ( NULL == destChildrenLink ) || ( getAllowableActions().get() &&
             !getAllowableActions()->isAllowed( libcmis::ObjectAction::MoveObject ) ) )
@@ -311,7 +311,7 @@ void AtomObject::move( boost::shared_ptr< libcmis::Folder > source, boost::share
 
 string AtomObject::getInfosUrl( )
 {
-    AtomLink* selfLink = getLink( "self", "application/atom+xml;type=entry" );
+    const AtomLink* selfLink = getLink( "self", "application/atom+xml;type=entry" );
     if ( NULL != selfLink )
         return selfLink->getHref( );
     return string( );

--- a/src/libcmis/ws-object-type.cxx
+++ b/src/libcmis/ws-object-type.cxx
@@ -66,7 +66,7 @@ WSObjectType& WSObjectType::operator=( const WSObjectType& copy )
 void WSObjectType::refresh( )
 {
     libcmis::ObjectTypePtr type = m_session->getType( m_id );
-    WSObjectType* const other = dynamic_cast< WSObjectType* >( type.get( ) );
+    const WSObjectType* const other = dynamic_cast< WSObjectType* >( type.get( ) );
     if ( other != NULL )
         *this = *other;
 }

--- a/src/libcmis/ws-object.cxx
+++ b/src/libcmis/ws-object.cxx
@@ -105,7 +105,7 @@ libcmis::ObjectPtr WSObject::updateProperties(
 void WSObject::refresh( )
 {
     libcmis::ObjectPtr object = m_session->getObject( getId( ) );
-    WSObject* const other = dynamic_cast< WSObject* >( object.get( ) );
+    const WSObject* const other = dynamic_cast< WSObject* >( object.get( ) );
     if ( other != NULL )
         *this = *other;
 }


### PR DESCRIPTION
src/libcmis/atom-document.cxx:303:15: style: Variable 'link' can be declared as pointer to const [constVariablePointer]
src/libcmis/atom-document.cxx:397:15: style: Variable 'link' can be declared as pointer to const [constVariablePointer]
src/libcmis/atom-folder.cxx:63:15: style: Variable 'childrenLink' can be declared as pointer to const [constVariablePointer]
src/libcmis/atom-folder.cxx:266:15: style: Variable 'treeLink' can be declared as pointer to const [constVariablePointer]
src/libcmis/atom-object.cxx:260:15: style: Variable 'destChildrenLink' can be declared as pointer to const [constVariablePointer]
src/libcmis/atom-object.cxx:314:15: style: Variable 'selfLink' can be declared as pointer to const [constVariablePointer]
src/libcmis/ws-object-type.cxx:69:25: style: Variable 'other' can be declared as pointer to const [constVariablePointer]
src/libcmis/ws-object.cxx:108:21: style: Variable 'other' can be declared as pointer to const [constVariablePointer]