### PR TITLE
cppcheck: fix passedByValue (part 1)

### DIFF
--- a/inc/libcmis/xml-utils.hxx
+++ b/inc/libcmis/xml-utils.hxx
@@ -124,7 +124,7 @@ namespace libcmis
       */
     LIBCMIS_API void registerSoapNamespaces( xmlXPathContextPtr xpathCtx );
 
-    LIBCMIS_API std::string getXPathValue( xmlXPathContextPtr xpathCtx, std::string req );
+    LIBCMIS_API std::string getXPathValue( xmlXPathContextPtr xpathCtx, const std::string& req );
 
     LIBCMIS_API xmlDocPtr wrapInDoc( xmlNodePtr entryNode );
 
@@ -138,16 +138,16 @@ namespace libcmis
 
     /** Parse a xsd:dateTime string and return the corresponding UTC posix time.
      */
-    LIBCMIS_API boost::posix_time::ptime parseDateTime( std::string dateTimeStr );
+    LIBCMIS_API boost::posix_time::ptime parseDateTime( const std::string& dateTimeStr );
 
     /// Write a UTC time object to an xsd:dateTime string
     LIBCMIS_API std::string writeDateTime( boost::posix_time::ptime time );
 
-    LIBCMIS_API bool parseBool( std::string str );
+    LIBCMIS_API bool parseBool( const std::string& str );
 
-    LIBCMIS_API long parseInteger( std::string str );
+    LIBCMIS_API long parseInteger( const std::string& str );
 
-    LIBCMIS_API double parseDouble( std::string str );
+    LIBCMIS_API double parseDouble( const std::string& str );
 
     /** Trim spaces on the left and right of a string.
      */
@@ -159,9 +159,9 @@ namespace libcmis
 
     LIBCMIS_API int stringstream_write_callback(void * context, const char * s, int len);
 
-    LIBCMIS_API std::string escape( std::string str );
+    LIBCMIS_API std::string escape( const std::string& str );
 
-    LIBCMIS_API std::string unescape( std::string str );
+    LIBCMIS_API std::string unescape( const std::string& str );
 }
 
 #endif

--- a/src/libcmis/ws-versioningservice.cxx
+++ b/src/libcmis/ws-versioningservice.cxx
@@ -67,7 +67,7 @@ VersioningService& VersioningService::operator=( const VersioningService& copy )
     return *this;
 }
 
-libcmis::DocumentPtr VersioningService::checkOut( string repoId, string documentId )
+libcmis::DocumentPtr VersioningService::checkOut( const string& repoId, const string& documentId )
 {
     libcmis::DocumentPtr pwc;
 
@@ -88,7 +88,7 @@ libcmis::DocumentPtr VersioningService::checkOut( string repoId, string document
     return pwc;
 }
 
-void VersioningService::cancelCheckOut( string repoId, string documentId )
+void VersioningService::cancelCheckOut( const string& repoId, const string& documentId )
 {
     CancelCheckOutRequest request( repoId, documentId );
     m_session->soapRequest( m_url, request );
@@ -118,7 +118,7 @@ libcmis::DocumentPtr VersioningService::checkIn( string repoId, string objectId,
     return newVersion;
 }
 
-vector< libcmis::DocumentPtr > VersioningService::getAllVersions( string repoId, string objectId )
+vector< libcmis::DocumentPtr > VersioningService::getAllVersions( const string& repoId, const string& objectId )
 {
     vector< libcmis::DocumentPtr > versions;
 

--- a/src/libcmis/ws-versioningservice.hxx
+++ b/src/libcmis/ws-versioningservice.hxx
@@ -48,16 +48,16 @@ class VersioningService
 
         VersioningService& operator=( const VersioningService& copy );
 
-        libcmis::DocumentPtr checkOut( std::string repoId, std::string documentId );
+        libcmis::DocumentPtr checkOut( const std::string& repoId, const std::string& documentId );
 
-        void cancelCheckOut( std::string repoId, std::string documentId );
+        void cancelCheckOut( const std::string& repoId, const std::string& documentId );
 
         libcmis::DocumentPtr checkIn( std::string repoId, std::string objectId, bool isMajor,
                 const std::map< std::string, libcmis::PropertyPtr >& properties,
                 boost::shared_ptr< std::ostream > stream, std::string contentType,
                 std::string fileName, std::string comment );
 
-        std::vector< libcmis::DocumentPtr > getAllVersions( std::string repoId, std::string objectId );
+        std::vector< libcmis::DocumentPtr > getAllVersions( const std::string& repoId, const std::string& objectId );
 
     private:
 

--- a/src/libcmis/xml-utils.cxx
+++ b/src/libcmis/xml-utils.cxx
@@ -341,7 +341,7 @@ namespace libcmis
         }
     }
 
-    string getXPathValue( xmlXPathContextPtr xpathCtx, string req )
+    string getXPathValue( xmlXPathContextPtr xpathCtx, const string& req )
     {
         string value;
         if ( xpathCtx != NULL )
@@ -387,7 +387,7 @@ namespace libcmis
         return value;
     }
 
-    boost::posix_time::ptime parseDateTime( string dateTimeStr )
+    boost::posix_time::ptime parseDateTime( const string& dateTimeStr )
     {
         boost::posix_time::ptime t( boost::date_time::not_a_date_time );
         // Get the time zone offset
@@ -466,7 +466,7 @@ namespace libcmis
         return str;
     }
 
-    bool parseBool( string boolStr )
+    bool parseBool( const string& boolStr )
     {
         bool value = false;
         if ( boolStr == "true" || boolStr == "1" )
@@ -478,7 +478,7 @@ namespace libcmis
         return value;
     }
 
-    long parseInteger( string intStr )
+    long parseInteger( const string& intStr )
     {
         char* end;
         errno = 0;
@@ -497,7 +497,7 @@ namespace libcmis
         return value;
     }
 
-    double parseDouble( string doubleStr )
+    double parseDouble( const string& doubleStr )
     {
         char* end;
         errno = 0;
@@ -559,13 +559,13 @@ namespace libcmis
         return 0;
     }
 
-    string escape( string str )
+    string escape( const string& str )
     {
         std::unique_ptr< char, void(*)( void* ) > escaped{ curl_easy_escape( NULL, str.c_str(), str.length() ), curl_free };
         return escaped.get();
     }
 
-    string unescape( string str )
+    string unescape( const string& str )
     {
         std::unique_ptr< char, void(*)( void* ) > unescaped{ curl_easy_unescape( NULL, str.c_str(), str.length(), NULL ), curl_free };
         return unescaped.get();


### PR DESCRIPTION
src/libcmis/ws-versioningservice.cxx:70:58: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-versioningservice.cxx:70:73: performance: Function parameter 'documentId' should be passed by const reference. [passedByValue]
src/libcmis/ws-versioningservice.cxx:91:48: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-versioningservice.cxx:91:63: performance: Function parameter 'documentId' should be passed by const reference. [passedByValue]
src/libcmis/ws-versioningservice.cxx:121:74: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-versioningservice.cxx:121:89: performance: Function parameter 'objectId' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:344:63: performance: Function parameter 'req' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:390:52: performance: Function parameter 'dateTimeStr' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:469:28: performance: Function parameter 'boolStr' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:481:31: performance: Function parameter 'intStr' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:500:32: performance: Function parameter 'doubleStr' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:562:27: performance: Function parameter 'str' should be passed by const reference. [passedByValue]
src/libcmis/xml-utils.cxx:568:29: performance: Function parameter 'str' should be passed by const reference. [passedByValue]