### PR TITLE
cppcheck: fix passedByValue (part 2)

### DIFF
--- a/src/libcmis/ws-objectservice.cxx
+++ b/src/libcmis/ws-objectservice.cxx
@@ -67,7 +67,7 @@ ObjectService& ObjectService::operator=( const ObjectService& copy )
     return *this;
 }
 
-libcmis::ObjectPtr ObjectService::getObject( string repoId, string id )
+libcmis::ObjectPtr ObjectService::getObject( const string& repoId, const string& id )
 {
     libcmis::ObjectPtr object;
 
@@ -84,7 +84,7 @@ libcmis::ObjectPtr ObjectService::getObject( string repoId, string id )
     return object;
 }
 
-libcmis::ObjectPtr ObjectService::getObjectByPath( string repoId, string path )
+libcmis::ObjectPtr ObjectService::getObjectByPath( const string& repoId, const string& path )
 {
     libcmis::ObjectPtr object;
 
@@ -102,7 +102,7 @@ libcmis::ObjectPtr ObjectService::getObjectByPath( string repoId, string path )
 }
 
 vector< libcmis::RenditionPtr > ObjectService::getRenditions(
-        string repoId, string objectId, string filter )
+        const string& repoId, const string& objectId, const string& filter )
 {
     vector< libcmis::RenditionPtr > renditions;
 
@@ -144,13 +144,13 @@ libcmis::ObjectPtr ObjectService::updateProperties(
     return object;
 }
 
-void ObjectService::deleteObject( string repoId, string id, bool allVersions )
+void ObjectService::deleteObject( const string& repoId, const string& id, bool allVersions )
 {
     DeleteObjectRequest request( repoId, id, allVersions );
     m_session->soapRequest( m_url, request );
 }
         
-vector< string > ObjectService::deleteTree( std::string repoId, std::string folderId, bool allVersions,
+vector< string > ObjectService::deleteTree( const std::string& repoId, const std::string& folderId, bool allVersions,
         libcmis::UnfileObjects::Type unfile, bool continueOnFailure )
 {
     vector< string > failedIds;
@@ -168,13 +168,13 @@ vector< string > ObjectService::deleteTree( std::string repoId, std::string fold
     return failedIds;
 }
 
-void ObjectService::move( string repoId, string objectId, string destId, string srcId )
+void ObjectService::move( const string& repoId, const string& objectId, const string& destId, const string& srcId )
 {
     MoveObjectRequest request( repoId, objectId, destId, srcId );
     m_session->soapRequest( m_url, request );
 }
 
-boost::shared_ptr< istream > ObjectService::getContentStream( string repoId, string objectId )
+boost::shared_ptr< istream > ObjectService::getContentStream( const string& repoId, const string& objectId )
 {
     boost::shared_ptr< istream > stream;
 
@@ -191,8 +191,8 @@ boost::shared_ptr< istream > ObjectService::getContentStream( string repoId, str
     return stream;
 }
 
-void ObjectService::setContentStream( std::string repoId, std::string objectId, bool overwrite, std::string changeToken,
-        boost::shared_ptr< std::ostream > stream, std::string contentType, std::string fileName )
+void ObjectService::setContentStream( const std::string& repoId, const std::string& objectId, bool overwrite, const std::string& changeToken,
+        boost::shared_ptr< std::ostream > stream, const std::string& contentType, const std::string& fileName )
 {
     SetContentStreamRequest request( repoId, objectId, overwrite, changeToken, stream, contentType, fileName );
     m_session->soapRequest( m_url, request );

--- a/src/libcmis/ws-objectservice.hxx
+++ b/src/libcmis/ws-objectservice.hxx
@@ -55,12 +55,12 @@ class ObjectService
 
         ObjectService& operator=( const ObjectService& copy );
 
-        libcmis::ObjectPtr getObject( std::string repoId, std::string id );
+        libcmis::ObjectPtr getObject( const std::string& repoId, const std::string& id );
 
-        libcmis::ObjectPtr getObjectByPath( std::string repoId, std::string path );
+        libcmis::ObjectPtr getObjectByPath( const std::string& repoId, const std::string& path );
 
         std::vector< libcmis::RenditionPtr > getRenditions(
-                std::string repoId, std::string objectId, std::string filter );
+                const std::string& repoId, const std::string& objectId, const std::string& filter );
         
         libcmis::ObjectPtr updateProperties(
                 std::string repoId,
@@ -68,17 +68,17 @@ class ObjectService
                 const std::map< std::string, libcmis::PropertyPtr > & properties,
                 std::string changeToken );
 
-        void deleteObject( std::string repoId, std::string id, bool allVersions );
+        void deleteObject( const std::string& repoId, const std::string& id, bool allVersions );
         
-        std::vector< std::string > deleteTree( std::string repoId, std::string folderId, bool allVersions,
+        std::vector< std::string > deleteTree( const std::string& repoId, const std::string& folderId, bool allVersions,
                 libcmis::UnfileObjects::Type unfile, bool continueOnFailure );
 
-        void move( std::string repoId, std::string objectId, std::string destId, std::string srcId );
+        void move( const std::string& repoId, const std::string& objectId, const std::string& destId, const std::string& srcId );
 
-        boost::shared_ptr< std::istream > getContentStream( std::string repoId, std::string objectId );
+        boost::shared_ptr< std::istream > getContentStream( const std::string& repoId, const std::string& objectId );
 
-        void setContentStream( std::string repoId, std::string objectId, bool overwrite, std::string changeToken,
-                boost::shared_ptr< std::ostream > stream, std::string contentType, std::string fileName );
+        void setContentStream( const std::string& repoId, const std::string& objectId, bool overwrite, const std::string& changeToken,
+                boost::shared_ptr< std::ostream > stream, const std::string& contentType, const std::string& fileName );
 
         libcmis::FolderPtr createFolder( std::string repoId, const std::map< std::string, libcmis::PropertyPtr >& properties,
                 std::string folderId );

--- a/src/libcmis/ws-relatedmultipart.cxx
+++ b/src/libcmis/ws-relatedmultipart.cxx
@@ -48,7 +48,7 @@ RelatedPart::RelatedPart( string& name, string& type, string& content ) :
 }
 
 // LCOV_EXCL_START
-string RelatedPart::toString( string cid )
+string RelatedPart::toString( const string& cid )
 {
     string buf;
 

--- a/src/libcmis/ws-relatedmultipart.hxx
+++ b/src/libcmis/ws-relatedmultipart.hxx
@@ -56,7 +56,7 @@ class RelatedPart
 
             \param cid the content Id to output
           */
-        std::string toString( std::string cid );
+        std::string toString( const std::string& cid );
 };
 typedef boost::shared_ptr< RelatedPart > RelatedPartPtr;
 

--- a/src/libcmis/ws-repositoryservice.cxx
+++ b/src/libcmis/ws-repositoryservice.cxx
@@ -84,7 +84,7 @@ map< string, string > RepositoryService::getRepositories( )
     return repositories;
 }
 
-libcmis::RepositoryPtr RepositoryService::getRepositoryInfo( string id )
+libcmis::RepositoryPtr RepositoryService::getRepositoryInfo( const string& id )
 {
     libcmis::RepositoryPtr repository;
 
@@ -101,7 +101,7 @@ libcmis::RepositoryPtr RepositoryService::getRepositoryInfo( string id )
     return repository;
 }
 
-libcmis::ObjectTypePtr RepositoryService::getTypeDefinition( string repoId, string typeId )
+libcmis::ObjectTypePtr RepositoryService::getTypeDefinition( const string& repoId, const string& typeId )
 {
     libcmis::ObjectTypePtr type;
 
@@ -118,7 +118,7 @@ libcmis::ObjectTypePtr RepositoryService::getTypeDefinition( string repoId, stri
     return type;
 }
 
-vector< libcmis::ObjectTypePtr > RepositoryService::getTypeChildren( string repoId, string typeId )
+vector< libcmis::ObjectTypePtr > RepositoryService::getTypeChildren( const string& repoId, const string& typeId )
 {
     vector< libcmis::ObjectTypePtr > children;
 

--- a/src/libcmis/ws-repositoryservice.hxx
+++ b/src/libcmis/ws-repositoryservice.hxx
@@ -57,11 +57,11 @@ class RepositoryService
 
         /** Get the repository information based on its identifier.
           */
-        libcmis::RepositoryPtr getRepositoryInfo( std::string id );
+        libcmis::RepositoryPtr getRepositoryInfo( const std::string& id );
 
-        libcmis::ObjectTypePtr getTypeDefinition( std::string repoId, std::string typeId );
+        libcmis::ObjectTypePtr getTypeDefinition( const std::string& repoId, const std::string& typeId );
 
-        std::vector< libcmis::ObjectTypePtr > getTypeChildren( std::string repoId, std::string typeId );
+        std::vector< libcmis::ObjectTypePtr > getTypeChildren( const std::string& repoId, const std::string& typeId );
 
     private:
 

--- a/src/libcmis/ws-requests.cxx
+++ b/src/libcmis/ws-requests.cxx
@@ -95,7 +95,7 @@ boost::shared_ptr< libcmis::Exception > getCmisException( const SoapFault& fault
     return exception;
 }
 
-void writeCmismStream( xmlTextWriterPtr writer, RelatedMultipart& multipart, boost::shared_ptr< ostream > os, string& contentType, string filename )
+void writeCmismStream( xmlTextWriterPtr writer, RelatedMultipart& multipart, boost::shared_ptr< ostream > os, string& contentType, const string& filename )
 {
     // Get the stream as a string
     istream is( os->rdbuf( ) );

--- a/src/libcmis/ws-requests.hxx
+++ b/src/libcmis/ws-requests.hxx
@@ -70,7 +70,7 @@ class CmisSoapFaultDetail : public SoapFaultDetail
 boost::shared_ptr< libcmis::Exception > getCmisException( const SoapFault& fault );
 
 void writeCmismStream( xmlTextWriterPtr writer, RelatedMultipart& multipart,
-        boost::shared_ptr< std::ostream >, std::string& contentType, std::string filename );
+        boost::shared_ptr< std::ostream >, std::string& contentType, const std::string& filename );
 
 /** getRepositories request.
   */

--- a/src/libcmis/ws-session.cxx
+++ b/src/libcmis/ws-session.cxx
@@ -41,8 +41,8 @@
 
 using namespace std;
 
-WSSession::WSSession( string bindingUrl, string repositoryId, string username,
-        string password, bool noSslCheck, libcmis::OAuth2DataPtr oauth2,
+WSSession::WSSession( const string& bindingUrl, const string& repositoryId, const string& username,
+        const string& password, bool noSslCheck, libcmis::OAuth2DataPtr oauth2,
         bool verbose ) :
     BaseSession( bindingUrl, repositoryId, username, password, noSslCheck, oauth2, verbose ),
     m_servicesUrls( ),
@@ -58,7 +58,7 @@ WSSession::WSSession( string bindingUrl, string repositoryId, string username,
     initialize( );
 }
 
-WSSession::WSSession( string bindingUrl, string repositoryId,
+WSSession::WSSession( const string& bindingUrl, const string& repositoryId,
                       const HttpSession& httpSession,
                       libcmis::HttpResponsePtr response ) :
     BaseSession( bindingUrl, repositoryId, httpSession ),
@@ -185,7 +185,7 @@ vector< SoapResponsePtr > WSSession::soapRequest( string& url, SoapRequest& requ
     return responses;
 }
 
-void WSSession::parseWsdl( string buf )
+void WSSession::parseWsdl( const string& buf )
 {
     // parse the content
     const boost::shared_ptr< xmlDoc > doc( xmlReadMemory( buf.c_str(), buf.size(), m_bindingUrl.c_str(), NULL, 0 ), xmlFreeDoc );
@@ -249,10 +249,10 @@ void WSSession::initializeResponseFactory( )
     m_responseFactory.setSession( this );
 }
 
-void WSSession::initializeRepositories( map< string, string > repositories )
+void WSSession::initializeRepositories( const map< string, string >& repositories )
 {
-    for ( map< string, string >::iterator it = repositories.begin( );
-          it != repositories.end( ); ++it )
+    for ( map< string, string >::const_iterator it = repositories.cbegin( );
+          it != repositories.cend( ); ++it )
     {
         string repoId = it->first;
         m_repositories.push_back( getRepositoryService( ).getRepositoryInfo( repoId ) );

--- a/src/libcmis/ws-session.hxx
+++ b/src/libcmis/ws-session.hxx
@@ -50,8 +50,8 @@ class WSSession : public BaseSession, public SoapSession
         SoapResponseFactory m_responseFactory;
 
     public:
-        WSSession( std::string bindingUrl, std::string repositoryId,
-                   std::string username, std::string password,
+        WSSession( const std::string& bindingUrl, const std::string& repositoryId,
+                   const std::string& username, const std::string& password,
                    bool noSslCheck = false,
                    libcmis::OAuth2DataPtr oauth2 = libcmis::OAuth2DataPtr(),
                    bool verbose = false );
@@ -60,7 +60,7 @@ class WSSession : public BaseSession, public SoapSession
             before to spare some HTTP request. This constructor has mostly
             been designed for the SessionFactory use.
           */
-        WSSession( std::string bindingUrl, std::string repositoryId,
+        WSSession( const std::string& bindingUrl, const std::string& repositoryId,
                    const HttpSession& HttpSession,
                    libcmis::HttpResponsePtr response );
         ~WSSession( );
@@ -112,9 +112,9 @@ class WSSession : public BaseSession, public SoapSession
         WSSession( const WSSession& copy ) = delete;
         WSSession& operator=( const WSSession& copy ) = delete;
 
-        void parseWsdl( std::string buf );
+        void parseWsdl( const std::string& buf );
         void initializeResponseFactory( );
-        void initializeRepositories( std::map< std::string, std::string > repositories );
+        void initializeRepositories( const std::map< std::string, std::string >& repositories );
         void initialize( libcmis::HttpResponsePtr response = libcmis::HttpResponsePtr() );
 
         std::map< std::string, SoapResponseCreator > getResponseMapping( );


### PR DESCRIPTION
src/libcmis/ws-objectservice.cxx:70:53: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:70:68: performance: Function parameter 'id' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:87:59: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:87:74: performance: Function parameter 'path' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:105:16: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:105:31: performance: Function parameter 'objectId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:105:48: performance: Function parameter 'filter' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:147:42: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:147:57: performance: Function parameter 'id' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:153:57: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:153:77: performance: Function parameter 'folderId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:171:34: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:171:49: performance: Function parameter 'objectId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:171:66: performance: Function parameter 'destId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:171:81: performance: Function parameter 'srcId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:177:70: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:177:85: performance: Function parameter 'objectId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:194:51: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:194:71: performance: Function parameter 'objectId' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:194:109: performance: Function parameter 'changeToken' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:195:63: performance: Function parameter 'contentType' should be passed by const reference. [passedByValue]
src/libcmis/ws-objectservice.cxx:195:88: performance: Function parameter 'fileName' should be passed by const reference. [passedByValue]
src/libcmis/ws-relatedmultipart.cxx:51:38: performance: Function parameter 'cid' should be passed by const reference. [passedByValue]
src/libcmis/ws-repositoryservice.cxx:87:69: performance: Function parameter 'id' should be passed by const reference. [passedByValue]
src/libcmis/ws-repositoryservice.cxx:104:69: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-repositoryservice.cxx:104:84: performance: Function parameter 'typeId' should be passed by const reference. [passedByValue]
src/libcmis/ws-repositoryservice.cxx:121:77: performance: Function parameter 'repoId' should be passed by const reference. [passedByValue]
src/libcmis/ws-repositoryservice.cxx:121:92: performance: Function parameter 'typeId' should be passed by const reference. [passedByValue]
src/libcmis/ws-requests.cxx:98:139: performance: Function parameter 'filename' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:44:30: performance: Function parameter 'bindingUrl' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:44:49: performance: Function parameter 'repositoryId' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:44:70: performance: Function parameter 'username' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:45:16: performance: Function parameter 'password' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:61:30: performance: Function parameter 'bindingUrl' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:61:49: performance: Function parameter 'repositoryId' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:188:35: performance: Function parameter 'buf' should be passed by const reference. [passedByValue]
src/libcmis/ws-session.cxx:252:63: performance: Function parameter 'repositories' should be passed by const reference. [passedByValue]