### PR TITLE
Revert partly cppcheck: fix passedByValue (part 1)

### DIFF
--- a/inc/libcmis/xml-utils.hxx
+++ b/inc/libcmis/xml-utils.hxx
@@ -124,7 +124,7 @@ namespace libcmis
       */
     LIBCMIS_API void registerSoapNamespaces( xmlXPathContextPtr xpathCtx );
 
-    LIBCMIS_API std::string getXPathValue( xmlXPathContextPtr xpathCtx, const std::string& req );
+    LIBCMIS_API std::string getXPathValue( xmlXPathContextPtr xpathCtx, std::string req );
 
     LIBCMIS_API xmlDocPtr wrapInDoc( xmlNodePtr entryNode );
 
@@ -138,16 +138,16 @@ namespace libcmis
 
     /** Parse a xsd:dateTime string and return the corresponding UTC posix time.
      */
-    LIBCMIS_API boost::posix_time::ptime parseDateTime( const std::string& dateTimeStr );
+    LIBCMIS_API boost::posix_time::ptime parseDateTime( std::string dateTimeStr );
 
     /// Write a UTC time object to an xsd:dateTime string
     LIBCMIS_API std::string writeDateTime( boost::posix_time::ptime time );
 
-    LIBCMIS_API bool parseBool( const std::string& str );
+    LIBCMIS_API bool parseBool( std::string str );
 
-    LIBCMIS_API long parseInteger( const std::string& str );
+    LIBCMIS_API long parseInteger( std::string str );
 
-    LIBCMIS_API double parseDouble( const std::string& str );
+    LIBCMIS_API double parseDouble( std::string str );
 
     /** Trim spaces on the left and right of a string.
      */
@@ -159,9 +159,9 @@ namespace libcmis
 
     LIBCMIS_API int stringstream_write_callback(void * context, const char * s, int len);
 
-    LIBCMIS_API std::string escape( const std::string& str );
+    LIBCMIS_API std::string escape( std::string str );
 
-    LIBCMIS_API std::string unescape( const std::string& str );
+    LIBCMIS_API std::string unescape( std::string str );
 }
 
 #endif

--- a/src/libcmis/xml-utils.cxx
+++ b/src/libcmis/xml-utils.cxx
@@ -341,7 +341,7 @@ namespace libcmis
         }
     }
 
-    string getXPathValue( xmlXPathContextPtr xpathCtx, const string& req )
+    string getXPathValue( xmlXPathContextPtr xpathCtx, string req )
     {
         string value;
         if ( xpathCtx != NULL )
@@ -387,7 +387,7 @@ namespace libcmis
         return value;
     }
 
-    boost::posix_time::ptime parseDateTime( const string& dateTimeStr )
+    boost::posix_time::ptime parseDateTime( string dateTimeStr )
     {
         boost::posix_time::ptime t( boost::date_time::not_a_date_time );
         // Get the time zone offset
@@ -466,7 +466,7 @@ namespace libcmis
         return str;
     }
 
-    bool parseBool( const string& boolStr )
+    bool parseBool( string boolStr )
     {
         bool value = false;
         if ( boolStr == "true" || boolStr == "1" )
@@ -478,7 +478,7 @@ namespace libcmis
         return value;
     }
 
-    long parseInteger( const string& intStr )
+    long parseInteger( string intStr )
     {
         char* end;
         errno = 0;
@@ -497,7 +497,7 @@ namespace libcmis
         return value;
     }
 
-    double parseDouble( const string& doubleStr )
+    double parseDouble( string doubleStr )
     {
         char* end;
         errno = 0;
@@ -559,13 +559,13 @@ namespace libcmis
         return 0;
     }
 
-    string escape( const string& str )
+    string escape( string str )
     {
         std::unique_ptr< char, void(*)( void* ) > escaped{ curl_easy_escape( NULL, str.c_str(), str.length() ), curl_free };
         return escaped.get();
     }
 
-    string unescape( const string& str )
+    string unescape( string str )
     {
         std::unique_ptr< char, void(*)( void* ) > unescaped{ curl_easy_unescape( NULL, str.c_str(), str.length(), NULL ), curl_free };
         return unescaped.get();


### PR DESCRIPTION
As requested in https://github.com/tdf/libcmis/pull/61#pullrequestreview-1913750576